### PR TITLE
Chore: Update copyright year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 mlengse
+Copyright (c) 2025 mlengse
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I've changed the copyright year in the MIT License file from 2017 to 2025. The copyright holder 'mlengse' remains unchanged as per your confirmation.